### PR TITLE
Added aqi for pm2.5 and pm10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Integration for the HPMA115S0 Dust and Particle Sensor into ESPHome
       name: "Particulate Matter 2.5"
     pm_10_0:
       name: "Particulate Matter 10.0"
+    # These aqi lines are optional
+    aqi_2_5:
+      name: "Air Quality Index Particulate Matter 2.5"
+    aqi_10_0:
+      name: "Air Quality Index Particulate Matter 10.0"
     #Uncomment below if you have the compact sensor
     #pm_1_0:
     #  name: "Particulate Matter 1.0"

--- a/custom_components/hpma115s0_esphome/hpma115s0_esphome.h
+++ b/custom_components/hpma115s0_esphome/hpma115s0_esphome.h
@@ -16,6 +16,9 @@ class HPMA115S0Component : public PollingComponent, public uart::UARTDevice {
   void set_pm_2_5_sensor(sensor::Sensor *pm_2_5_sensor) { pm_2_5_sensor_ = pm_2_5_sensor; }
   void set_pm_10_0_sensor(sensor::Sensor *pm_10_0_sensor) { pm_10_0_sensor_ = pm_10_0_sensor; }
 
+  void set_aqi_2_5_sensor(sensor::Sensor *aqi_2_5_sensor) { aqi_2_5_sensor_ = aqi_2_5_sensor; }
+  void set_aqi_10_0_sensor(sensor::Sensor *aqi_10_0_sensor) { aqi_10_0_sensor_ = aqi_10_0_sensor; }
+
   void set_pm_4_0_sensor(sensor::Sensor *pm_4_0_sensor) { pm_4_0_sensor_ = pm_4_0_sensor; }
   void set_pm_1_0_sensor(sensor::Sensor *pm_1_0_sensor) { pm_1_0_sensor_ = pm_1_0_sensor; }
 
@@ -29,6 +32,9 @@ class HPMA115S0Component : public PollingComponent, public uart::UARTDevice {
   sensor::Sensor *pm_2_5_sensor_{nullptr};
   sensor::Sensor *pm_10_0_sensor_{nullptr};
 
+  sensor::Sensor *aqi_2_5_sensor_{nullptr};
+  sensor::Sensor *aqi_10_0_sensor_{nullptr};
+
   sensor::Sensor *pm_4_0_sensor_{nullptr};
   sensor::Sensor *pm_1_0_sensor_{nullptr};
 
@@ -36,6 +42,8 @@ class HPMA115S0Component : public PollingComponent, public uart::UARTDevice {
   bool success;
   float p25 = 0;
   float p10 = 0;
+  float aqi25 = 0;
+  float aqi10 = 0;
   float p4 = 0;
   float p1 = 0;
 
@@ -58,6 +66,8 @@ class HPMA115S0Component : public PollingComponent, public uart::UARTDevice {
   bool stop_measurement(void);
   bool stop_autosend(void);
   bool enable_autosend(void);
+  float calcAQI2_5() const;
+  float calcAQI10() const;
 };
 
 }  // namespace hpma115S0_esphome

--- a/custom_components/hpma115s0_esphome/sensor.py
+++ b/custom_components/hpma115s0_esphome/sensor.py
@@ -7,6 +7,7 @@ from esphome.const import (
     CONF_PM_10_0,
     CONF_PM_1_0, #new
     CONF_PM_4_0, #new
+    DEVICE_CLASS_AQI, #new
     DEVICE_CLASS_PM1, #new
     DEVICE_CLASS_PM10,
     DEVICE_CLASS_PM25,
@@ -22,6 +23,10 @@ hpma115s0_ns = cg.esphome_ns.namespace("hpma115S0_esphome") #OLD: hm3301_ns = cg
 HPMA115S0Component = hpma115s0_ns.class_(
     "HPMA115S0Component", uart.UARTDevice, cg.PollingComponent
 )
+
+CONF_AQI_2_5 = "aqi_2_5"
+CONF_AQI_10_0 = "aqi_10_0"
+UNIT_INDEX = "index"
 
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
@@ -39,6 +44,20 @@ CONFIG_SCHEMA = cv.All(
                 icon=ICON_CHEMICAL_WEAPON,
                 accuracy_decimals=0,
                 device_class=DEVICE_CLASS_PM10,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_AQI_2_5): sensor.sensor_schema(
+                unit_of_measurement=UNIT_INDEX,
+                icon=ICON_CHEMICAL_WEAPON,
+                accuracy_decimals=0,
+                device_class=DEVICE_CLASS_AQI,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_AQI_10_0): sensor.sensor_schema(
+                unit_of_measurement=UNIT_INDEX,
+                icon=ICON_CHEMICAL_WEAPON,
+                accuracy_decimals=0,
+                device_class=DEVICE_CLASS_AQI,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_PM_1_0): sensor.sensor_schema(
@@ -75,6 +94,14 @@ async def to_code(config):
     if CONF_PM_10_0 in config:
         sens = await sensor.new_sensor(config[CONF_PM_10_0])
         cg.add(var.set_pm_10_0_sensor(sens))
+
+    if CONF_AQI_2_5 in config:
+        sens = await sensor.new_sensor(config[CONF_AQI_2_5])
+        cg.add(var.set_aqi_2_5_sensor(sens))
+
+    if CONF_AQI_10_0 in config:
+        sens = await sensor.new_sensor(config[CONF_AQI_10_0])
+        cg.add(var.set_aqi_10_0_sensor(sens))
 
     if CONF_PM_4_0 in config:
         sens = await sensor.new_sensor(config[CONF_PM_4_0])


### PR DESCRIPTION
## Overview

Added optional configs for aqi based on pm2.5 and pm10.0. These are based on the US EPA guidelines (for what it is worth). They should be optional.

I'm not sure I did the config parts correctly in sensor.py. I loosely followed the aqi stuff in hm3301.

## Verification

I added them to my config and they are working fine. I can also confirm the PM1 and PM4 are showing up fine.

![screenshot-2022-10-16-1665935311](https://user-images.githubusercontent.com/1812882/196044876-8d4757fa-2ff8-48f2-96e8-34c2bd6395cd.png)

That's nice to see. 

During development, One of the aqi pm2.5 or aqi pm10.0 wasn't logging that it was being reported. But they both are now. I am not sure if this is a logging error, or if I had a bug/race condition. They are both reporting fine in HA currently. But take a close look to see if I put a PM2.5 where I should have a PM10 or something.